### PR TITLE
Features/provide field extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Or install it yourself as:
 
 ## Usage
 
-1. Use `GraphQL::ResultCache` as a plugin in your schema.
- 
+1. Use `GraphQL::ResultCache` as a plugin in your schema. Only for implementations using `graphql < 1.10.0`.
+
 ```ruby
 class MySchema < GraphQL::Schema
   mutation Types::MutationType
   query Types::QueryType
- 
+
   use GraphQL::ResultCache
 end
 ```
@@ -41,7 +41,19 @@ module Types
 end
 ```
 
-3. Config the fields which need to be cached with `result_cache` definition.
+3. Config the fields which need to be cached.
+
+There are two approaches available to config the caching for the field.
+Using currently supported [GraphQL gem](https://graphql-ruby.org/) `Field Extension` interface or `Field Instrument` interface
+which is no longer supported as of `graphql 1.10.0`.
+
+#### Field Extension:
+```ruby
+field :theme, Types::ThemeType, null: false, extensions: [GraphQL::ResultCache::FieldExtension]
+```
+
+#### Field Instrument:
+Only to be used for implementations where `graphql < 1.10.0`.
 
 ```ruby
 field :theme, Types::ThemeType, null: false, result_cache: true
@@ -66,17 +78,33 @@ end
 ## Result Cache Customization
 
 ### Cache condition
+The `if` condition can be either a Symbol or a Proc.
 
+#### Field Extension
+```ruby
+field :theme, Types::ThemeType, null: false, do
+  extension GraphQL::ResultCache::FieldExtension, if: :published?
+end
+```
+
+#### Field Instrument
 ```ruby
 field :theme, Types::ThemeType, null: false, result_cache: { if: :published? }
 ```
-The `if` condition can be either a Symbol or a Proc.
 
 ### Customized cache key
 
-By default, `GraphQL::ResultCache` will generate a cache key combining the field path, arguments and object. 
+By default, `GraphQL::ResultCache` will generate a cache key combining the field path, arguments and object.
 But you can customize the object clause by specify the `key` option.
 
+#### Field Extension
+```ruby
+field :theme, Types::ThemeType, null: false, do
+  extension GraphQL::ResultCache::FieldExtension, key: :theme_cache_key
+end
+```
+
+#### Field Instrument
 ```ruby
 field :theme, Types::ThemeType, null: false, result_cache: { key: :theme_cache_key }
 ```
@@ -86,6 +114,14 @@ The `key` can be either a Symbol or a Proc.
 
 An `after_process` callback can be provided, eg. when some dynamic values need to be amended after cached result applied.
 
+#### Field Extension
+```ruby
+field :theme, Types::ThemeType, null: false, do
+  extension GraphQL::ResultCache::FieldExtension, after_process: :amend_dynamic_attributes
+end
+```
+
+#### Field Instrument
 ```ruby
 field :theme, Types::ThemeType, null: false, result_cache: { after_process: :amend_dynamic_attributes }
 

--- a/lib/graphql/result_cache.rb
+++ b/lib/graphql/result_cache.rb
@@ -3,6 +3,7 @@ require 'graphql/result_cache/version'
 require 'graphql/result_cache/field'
 require 'graphql/result_cache/result'
 require 'graphql/result_cache/field_instrument'
+require 'graphql/result_cache/field_extension'
 require 'graphql/result_cache/introspection'
 
 module GraphQL

--- a/lib/graphql/result_cache.rb
+++ b/lib/graphql/result_cache.rb
@@ -1,5 +1,6 @@
 require 'graphql'
 require 'graphql/result_cache/version'
+require 'graphql/result_cache/errors'
 require 'graphql/result_cache/field'
 require 'graphql/result_cache/result'
 require 'graphql/result_cache/field_instrument'
@@ -39,7 +40,14 @@ module GraphQL
     @namespace = 'GraphQL:Result'
 
     def self.use(schema_def, options: {})
-      schema_def.instrument(:field, ::GraphQL::ResultCache::FieldInstrument.new)
+      if Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new('1.10.0')
+        raise(
+          ::GraphQL::ResultCache::DeprecatedError,
+          'Field Instruments are no longer supported, please use Field Extensions'
+        )
+      else
+        schema_def.instrument(:field, ::GraphQL::ResultCache::FieldInstrument.new)
+      end
     end
   end
 end

--- a/lib/graphql/result_cache/callback.rb
+++ b/lib/graphql/result_cache/callback.rb
@@ -22,7 +22,7 @@ module GraphQL
       private
 
       def callback_caller
-        ctx_path || @field.name
+        ctx_path || @field.path
       end
 
       def ctx_path

--- a/lib/graphql/result_cache/callback.rb
+++ b/lib/graphql/result_cache/callback.rb
@@ -1,21 +1,32 @@
 module GraphQL
   module ResultCache
     class Callback
-      def initialize obj:, args:, ctx:, value:
+      def initialize(obj:, args:, ctx:, value:, field: nil)
         @obj = obj
         @args = args
         @ctx = ctx
         @value = value
+        @field = field
       end
 
-      def call result_hash
+      def call(result_hash)
         case @value
           when Symbol
             @obj.public_send(@value, result_hash)
           when Proc
             @value.call(result_hash, @obj, @args, @ctx)
         end
-        ::GraphQL::ResultCache.logger && ::GraphQL::ResultCache.logger.debug("GraphQL result cache callback called for #{@ctx.path.join('.')}")
+        ::GraphQL::ResultCache.logger && ::GraphQL::ResultCache.logger.debug("GraphQL result cache callback called for #{callback_caller}")
+      end
+
+      private
+
+      def callback_caller
+        ctx_path || @field.name
+      end
+
+      def ctx_path
+        @ctx.path.empty? ? nil : @ctx.path.join('.')
       end
     end
   end

--- a/lib/graphql/result_cache/errors.rb
+++ b/lib/graphql/result_cache/errors.rb
@@ -1,0 +1,5 @@
+module GraphQL
+  module ResultCache
+    class DeprecatedError < StandardError; end
+  end
+end

--- a/lib/graphql/result_cache/field_extension.rb
+++ b/lib/graphql/result_cache/field_extension.rb
@@ -36,6 +36,7 @@ module GraphQL
           obj: object,
           args: arguments,
           ctx: context,
+          field: @field,
           key: config[:key]
         )
       end

--- a/lib/graphql/result_cache/field_extension.rb
+++ b/lib/graphql/result_cache/field_extension.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'graphql/result_cache/condition'
+require 'graphql/result_cache/context_config'
+require 'graphql/result_cache/key'
+require 'graphql/result_cache/callback'
+
+module GraphQL
+  module ResultCache
+    class FieldExtension < GraphQL::Schema::FieldExtension
+      def resolve(object:, arguments:, **rest)
+        cache_config = options.is_a?(Hash) ? options : {}
+        context = object.context
+
+        if Condition.new(cache_config, obj: object, args: arguments, ctx: context).true?
+          context[:result_cache] ||= ContextConfig.new
+          cached = add_to_context_result_cache(context, object, arguments, cache_config)
+        end
+
+        yield(object, arguments) unless cached
+      end
+
+      private
+
+      def add_to_context_result_cache(context, object, arguments, cache_config)
+        cache_key = key(object, arguments, context, cache_config)
+        after_process = after_process(object, arguments, context, cache_config)
+        context[:result_cache].add(
+          context: context,
+          key: cache_key.to_s,
+          after_process: after_process
+        )
+      end
+
+      def key(object, arguments, context, config)
+        Key.new(
+          obj: object,
+          args: arguments,
+          ctx: context,
+          key: config[:key]
+        )
+      end
+
+      def after_process(object, arguments, context, config)
+        return unless config[:after_process]
+
+        Callback.new(
+          obj: object,
+          args: arguments,
+          ctx: context,
+          value: config[:after_process]
+        )
+      end
+    end
+  end
+end

--- a/lib/graphql/result_cache/field_extension.rb
+++ b/lib/graphql/result_cache/field_extension.rb
@@ -8,9 +8,8 @@ require 'graphql/result_cache/callback'
 module GraphQL
   module ResultCache
     class FieldExtension < GraphQL::Schema::FieldExtension
-      def resolve(object:, arguments:, **rest)
+      def resolve(object:, arguments:, context:)
         cache_config = options.is_a?(Hash) ? options : {}
-        context = object.context
 
         if Condition.new(cache_config, obj: object, args: arguments, ctx: context).true?
           context[:result_cache] ||= ContextConfig.new

--- a/lib/graphql/result_cache/field_extension.rb
+++ b/lib/graphql/result_cache/field_extension.rb
@@ -48,6 +48,7 @@ module GraphQL
           obj: object,
           args: arguments,
           ctx: context,
+          field: @field,
           value: config[:after_process]
         )
       end

--- a/lib/graphql/result_cache/key.rb
+++ b/lib/graphql/result_cache/key.rb
@@ -29,7 +29,7 @@ module GraphQL
       end
 
       def field_clause
-        @field.name unless @field.nil?
+        @field.path unless @field.nil?
       end
 
       def args_clause

--- a/lib/graphql/result_cache/key.rb
+++ b/lib/graphql/result_cache/key.rb
@@ -1,17 +1,21 @@
+# frozen_string_literal: true
+
 module GraphQL
   module ResultCache
     class Key
-      def initialize obj:, args:, ctx:, key: nil
+      def initialize(obj:, args:, ctx: nil, key: nil, field: nil)
         @obj = obj
         @args = args
         @ctx = ctx
         @key = key
+        @field = field
       end
 
       def to_s
         @to_s ||= [
             ::GraphQL::ResultCache.namespace,
             path_clause,
+            field_clause,
             args_clause,
             object_clause,
             client_hash_clause
@@ -21,7 +25,11 @@ module GraphQL
       private
 
       def path_clause
-        @ctx.path.join('.')
+        @ctx.path.join('.') unless @ctx.nil?
+      end
+
+      def field_clause
+        @field.name unless @field.nil?
       end
 
       def args_clause
@@ -53,7 +61,6 @@ module GraphQL
         return object.id if object.respond_to?(:id)
         object.object_id
       end
-
     end
   end
 end

--- a/spec/graphql/result_cache/callback_spec.rb
+++ b/spec/graphql/result_cache/callback_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+RSpec.describe GraphQL::ResultCache::Callback do
+  let(:field) { instance_double('GraphQL::Schema::Field', name: 'publishedForm') }
+  # let(:options) { nil }
+
+  let(:object) { double('object', a: 'object_a') }
+  let(:args) { { x: 1, y: 's' } }
+  let(:ctx) { instance_double('GraphQL::Context', path: %w[publishedForm form fields]) }
+  let(:value) { :a }
+
+  describe '#call' do
+    subject do
+      described_class
+        .new(obj: object, args: args, ctx: ctx, value: value, field: field)
+        .call(result)
+    end
+
+    let(:result) { { publishedForm: { x: :y } } }
+    let(:logger) { spy('logger') }
+
+    before { expect(GraphQL::ResultCache).to receive(:logger).twice.and_return(logger) }
+
+    context 'with symbol callback' do
+      it 'runs callback' do
+        expect(object).to receive(:public_send).with(:a, result)
+        subject
+      end
+    end
+
+    context 'with proc callback' do
+      let(:value) do
+        lambda do |result, obj, args, ctx|
+          "#{obj.a}-#{args[:x]}-#{ctx.path.join('/')}-#{result[:publishedForm][:x]}"
+        end
+      end
+
+      it 'runs callback' do
+        expect(value).to receive(:call).with(result, object, args, ctx)
+        subject
+      end
+    end
+
+    context 'with logging' do
+      context 'with context path' do
+        it 'logs callback' do
+          expect(logger).to receive(:debug)
+            .with('GraphQL result cache callback called for publishedForm.form.fields')
+          subject
+        end
+      end
+
+      context 'with field name' do
+        let(:ctx) { instance_double('GraphQL::Context', path: %w[]) }
+
+        it 'logs callback' do
+          expect(logger).to receive(:debug)
+            .with('GraphQL result cache callback called for publishedForm')
+          subject
+        end
+      end
+    end
+  end
+end

--- a/spec/graphql/result_cache/callback_spec.rb
+++ b/spec/graphql/result_cache/callback_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe GraphQL::ResultCache::Callback do
-  let(:field) { instance_double('GraphQL::Schema::Field', name: 'publishedForm') }
-  # let(:options) { nil }
-
+  let(:field) { instance_double('GraphQL::Schema::Field', path: 'publishedForm') }
   let(:object) { double('object', a: 'object_a') }
   let(:args) { { x: 1, y: 's' } }
   let(:ctx) { instance_double('GraphQL::Context', path: %w[publishedForm form fields]) }

--- a/spec/graphql/result_cache/field_extension_spec.rb
+++ b/spec/graphql/result_cache/field_extension_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe GraphQL::ResultCache::FieldExtension do
-  let(:field) { instance_double('GraphQL::Schema::Field', name: 'publishedForm') }
+  let(:field) { instance_double('GraphQL::Schema::Field', path: 'publishedForm') }
   let(:options) { nil }
   let(:extension) { described_class.new(field: field, options: options) }
 

--- a/spec/graphql/result_cache/field_extension_spec.rb
+++ b/spec/graphql/result_cache/field_extension_spec.rb
@@ -3,9 +3,7 @@ require 'spec_helper'
 RSpec.describe GraphQL::ResultCache::FieldExtension do
   let(:field) { instance_double('GraphQL::Schema::Field', name: 'publishedForm') }
   let(:options) { nil }
-  let(:extension) do
-    GraphQL::ResultCache::FieldExtension.new(field: field, options: options)
-  end
+  let(:extension) { described_class.new(field: field, options: options) }
 
   describe '#resolve' do
     subject do
@@ -49,7 +47,7 @@ RSpec.describe GraphQL::ResultCache::FieldExtension do
 
         it 'adds field to cache' do
           expect(GraphQL::ResultCache::Callback).to receive(:new)
-            .with(obj: obj, args: args, ctx: ctx, value: :foo)
+            .with(obj: obj, args: args, ctx: ctx, value: :foo, field: field)
             .and_return(callback)
 
           expect(context_config).to receive(:add)

--- a/spec/graphql/result_cache/field_extension_spec.rb
+++ b/spec/graphql/result_cache/field_extension_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+RSpec.describe GraphQL::ResultCache::FieldExtension do
+  let(:field) { instance_double('GraphQL::Schema::Field') }
+  let(:options) { nil }
+  let(:extension) do
+    GraphQL::ResultCache::FieldExtension.new(field: field, options: options)
+  end
+
+  describe '#resolve' do
+    subject do
+      extension.resolve(object: obj, arguments: args) { |obj, args| true }
+    end
+
+    let(:obj) { double('obj', context: ctx, object: nil) }
+    let(:args) { double('args', to_h: {}) }
+    let(:ctx) { instance_double('GraphQL::Context', path: path) }
+    let(:path) { %w[publishedForm form fields] }
+    let(:context_config) { instance_double('GraphQL::ResultCache::ContextConfig') }
+    let(:cache_key) { 'GraphQL:Result:publishedForm.form.fields' }
+
+    context 'when condition passed' do
+      let(:cache_config) { {} }
+
+      before do
+        expect(ctx).to receive(:[])
+          .with(:result_cache)
+          .twice
+          .and_return(context_config)
+
+        expect(GraphQL::ResultCache::Condition).to receive(:new)
+          .with(cache_config, obj: obj, args: args, ctx: ctx)
+          .and_call_original
+      end
+
+      it 'adds field to cache' do
+        expect(context_config).to receive(:add)
+          .with(context: ctx, key: cache_key, after_process: nil)
+
+        is_expected.to be true
+      end
+
+      context 'with after process callback' do
+        let(:cache_config) { options }
+        let(:options) { { after_process: :foo } }
+        let(:callback) { instance_double('GraphQL::ResultCache::Callback') }
+
+        it 'adds field to cache' do
+          expect(GraphQL::ResultCache::Callback).to receive(:new)
+            .with(obj: obj, args: args, ctx: ctx, value: :foo)
+            .and_return(callback)
+
+          expect(context_config).to receive(:add)
+            .with(context: ctx, key: cache_key, after_process: callback)
+
+          is_expected.to be true
+        end
+      end
+    end
+
+    context 'when condition not passed' do
+      let(:condition) do
+        instance_double('GraphQL::ResultCache::Condition', true?: false)
+      end
+
+      it 'skips caching' do
+        expect(GraphQL::ResultCache::Condition).to receive(:new)
+          .with({}, obj: obj, args: args, ctx: ctx)
+          .and_return(condition)
+
+        is_expected.to be true
+      end
+    end
+
+    context 'when cached' do
+      let(:context_config) do
+        instance_double('GraphQL::ResultCache::ContextConfig', add: cached_object)
+      end
+      let(:cached_object) { double('cached_object') }
+
+      it 'shortcuts field execution' do
+        expect(ctx).to receive(:[])
+          .with(:result_cache)
+          .twice
+          .and_return(context_config)
+
+        expect(GraphQL::ResultCache::Condition).to receive(:new)
+          .with({}, obj: obj, args: args, ctx: ctx)
+          .and_call_original
+
+        is_expected.to be nil
+      end
+    end
+  end
+end

--- a/spec/graphql/result_cache/field_extension_spec.rb
+++ b/spec/graphql/result_cache/field_extension_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe GraphQL::ResultCache::FieldExtension do
 
   describe '#resolve' do
     subject do
-      extension.resolve(object: obj, arguments: args) { |obj, args| true }
+      extension.resolve(object: obj, arguments: args, context: ctx) { |obj, args| true }
     end
 
-    let(:obj) { double('obj', context: ctx, object: nil) }
+    let(:obj) { double('obj', object: nil) }
     let(:args) { double('args', to_h: {}) }
     let(:ctx) { instance_double('GraphQL::Context', path: path) }
     let(:path) { %w[publishedForm form fields] }
@@ -23,6 +23,8 @@ RSpec.describe GraphQL::ResultCache::FieldExtension do
       let(:cache_config) { {} }
 
       before do
+        allow(ctx).to receive(:[]).with(:result_cacheable).and_return true
+
         expect(ctx).to receive(:[])
           .with(:result_cache)
           .twice
@@ -79,6 +81,8 @@ RSpec.describe GraphQL::ResultCache::FieldExtension do
       let(:cached_object) { double('cached_object') }
 
       it 'shortcuts field execution' do
+        allow(ctx).to receive(:[]).with(:result_cacheable).and_return true
+
         expect(ctx).to receive(:[])
           .with(:result_cache)
           .twice

--- a/spec/graphql/result_cache/field_extension_spec.rb
+++ b/spec/graphql/result_cache/field_extension_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe GraphQL::ResultCache::FieldExtension do
-  let(:field) { instance_double('GraphQL::Schema::Field') }
+  let(:field) { instance_double('GraphQL::Schema::Field', name: 'publishedForm') }
   let(:options) { nil }
   let(:extension) do
     GraphQL::ResultCache::FieldExtension.new(field: field, options: options)
@@ -17,7 +17,7 @@ RSpec.describe GraphQL::ResultCache::FieldExtension do
     let(:ctx) { instance_double('GraphQL::Context', path: path) }
     let(:path) { %w[publishedForm form fields] }
     let(:context_config) { instance_double('GraphQL::ResultCache::ContextConfig') }
-    let(:cache_key) { 'GraphQL:Result:publishedForm.form.fields' }
+    let(:cache_key) { 'GraphQL:Result:publishedForm.form.fields:publishedForm' }
 
     context 'when condition passed' do
       let(:cache_config) { {} }

--- a/spec/graphql/result_cache/key_spec.rb
+++ b/spec/graphql/result_cache/key_spec.rb
@@ -6,9 +6,12 @@ RSpec.describe GraphQL::ResultCache::Key do
   let(:args) { {x: 1, y: 's'} }
   let(:path) { %w(publishedForm form fields) }
   let(:ctx) { double('ctx', path: path) }
+  let(:field) { nil }
   let(:key) { nil }
 
-  subject { GraphQL::ResultCache::Key.new(obj: obj, args: args, ctx: ctx, key: key) }
+  subject do
+    described_class.new(obj: obj, args: args, ctx: ctx, key: key, field: field)
+  end
 
   it 'should include path clause' do
     expect(subject.to_s).to include('publishedForm.form.fields')
@@ -16,6 +19,23 @@ RSpec.describe GraphQL::ResultCache::Key do
 
   it 'should include args clause' do
     expect(subject.to_s).to include('x:1:y:s')
+  end
+
+  context 'without context' do
+    let(:ctx) { nil }
+
+    it 'should produce key' do
+      expect(subject.to_s).not_to include('publishedForm.form.fields')
+    end
+  end
+
+  context 'with field clause' do
+    let(:ctx) { nil }
+    let(:field) { double('field', name: 'publishedForm') }
+
+    it 'should include field name' do
+      expect(subject.to_s).to include('publishedForm')
+    end
   end
 
   describe '#object_clause' do

--- a/spec/graphql/result_cache/key_spec.rb
+++ b/spec/graphql/result_cache/key_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe GraphQL::ResultCache::Key do
 
   context 'with field clause' do
     let(:ctx) { nil }
-    let(:field) { double('field', name: 'publishedForm') }
+    let(:field) { double('field', path: 'publishedForm') }
 
     it 'should include field name' do
       expect(subject.to_s).to include('publishedForm')

--- a/spec/graphql/result_cache_spec.rb
+++ b/spec/graphql/result_cache_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe GraphQL::ResultCache do
+  describe '.use' do
+    subject { described_class.use(schema) }
+
+    let(:schema) { instance_double('GraphQL::Schema') }
+
+    context 'when graphql version below 1.10' do
+      before do
+        stub_const('GraphQL::VERSION', '1.9.99')
+      end
+
+      it 'defines instrument on schema' do
+        expect(schema).to receive(:instrument)
+          .with(:field, an_instance_of(GraphQL::ResultCache::FieldInstrument))
+        subject
+      end
+    end
+
+    context 'when graphql version 1.10' do
+      before do
+        stub_const('GraphQL::VERSION', '1.10.0')
+      end
+
+      it 'raises error' do
+        expect { subject }.to raise_error(
+          GraphQL::ResultCache::DeprecatedError,
+          'Field Instruments are no longer supported, please use Field Extensions'
+        )
+      end
+    end
+
+    context 'when graphql version above 1.10' do
+      before do
+        stub_const('GraphQL::VERSION', '1.11.0')
+      end
+
+      it 'raises error' do
+        expect { subject }.to raise_error(
+          GraphQL::ResultCache::DeprecatedError,
+          'Field Instruments are no longer supported, please use Field Extensions'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
During an upgrade of the [graphql](https://github.com/rmosolgo/graphql-ruby) gem from `1.9.x` to `1.10.x` it became apparent that `Field Instrumentation` is no longer supported (extra info [here](https://github.com/rmosolgo/graphql-ruby/blob/master/guides/queries/interpreter.md#compatibility)) and that the `Field Extension` is the [supported replacement](https://github.com/rmosolgo/graphql-ruby/issues/2903#issuecomment-619391149) for that.

This PR introduces `Field Extension` API, which is based on the implementation of the `Field Instrument` interface. 

Further Field Extension documentation: https://graphql-ruby.org/type_definitions/field_extensions.html