### PR TITLE
Allow cache config to be an object

### DIFF
--- a/lib/graphql/result_cache/field_extension.rb
+++ b/lib/graphql/result_cache/field_extension.rb
@@ -9,7 +9,7 @@ module GraphQL
   module ResultCache
     class FieldExtension < GraphQL::Schema::FieldExtension
       def resolve(object:, arguments:, context:)
-        cache_config = options.is_a?(Hash) ? options : {}
+        cache_config = options.respond_to?(:to_h) ? options.to_h : {}
 
         if Condition.new(cache_config, obj: object, args: arguments, ctx: context).true?
           context[:result_cache] ||= ContextConfig.new

--- a/lib/graphql/result_cache/field_instrument.rb
+++ b/lib/graphql/result_cache/field_instrument.rb
@@ -21,7 +21,7 @@ module GraphQL
       def cached_resolve field
         old_resolve_proc = field.resolve_proc
         cache_config = field.metadata[:result_cache]
-        cache_config = {} unless cache_config.is_a?(Hash)
+        cache_config = cache_config.respond_to?(:to_h) ? cache_config.to_h : {}
         lambda do |obj, args, ctx|
           if Condition.new(cache_config, obj: obj, args: args, ctx: ctx).true?
             ctx[:result_cache] ||= ContextConfig.new

--- a/spec/graphql/result_cache/field_extension_spec.rb
+++ b/spec/graphql/result_cache/field_extension_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe GraphQL::ResultCache::FieldExtension do
       extension.resolve(object: obj, arguments: args, context: ctx) { |obj, args| true }
     end
 
-    let(:obj) { double('obj', object: nil) }
+    let(:obj) { double('obj', object: nil, cache_key: 'object_cache_key') }
     let(:args) { double('args', to_h: {}) }
     let(:ctx) { instance_double('GraphQL::Context', path: path) }
     let(:path) { %w[publishedForm form fields] }
@@ -52,6 +52,21 @@ RSpec.describe GraphQL::ResultCache::FieldExtension do
 
           expect(context_config).to receive(:add)
             .with(context: ctx, key: cache_key, after_process: callback)
+
+          is_expected.to be true
+        end
+      end
+
+      context 'when cache config as object' do
+        let(:options) { double('cache_config', to_h: { key: :cache_key }) }
+        let(:cache_config) { options.to_h }
+        let(:cache_key) do
+          'GraphQL:Result:publishedForm.form.fields:publishedForm:object_cache_key'
+        end
+
+        it 'adds field to cache' do
+          expect(context_config).to receive(:add)
+            .with(context: ctx, key: cache_key, after_process: nil)
 
           is_expected.to be true
         end


### PR DESCRIPTION
This PR allows the passed cache config to be an object that responds to hash (to_h) interface rather than strictly a Hash.

This allows passing better and cleaner configuration structures, especially useful when GraphQL version >= 1.10.0.

Branch on the main app: https://github.com/onrunning/on/tree/updates/graphql-cache-config-objects 

note: if https://github.com/onrunning/on/pull/2510 is not merged yet, you will locally have to point the gem to this branch
`gem 'graphql-result_cache',       github: 'onrunning/graphql-result_cache', branch: 'features/field-config-object'`